### PR TITLE
Add support for Pascal casing

### DIFF
--- a/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -86,7 +86,7 @@ object Configuration {
   }
 
   val pascalCaseTransformation: String => String = s => {
-    s"${Character.toUpperCase(s.charAt(0))}${s.substring(1)}"
+    s"${s.charAt(0).toUpper}${s.substring(1)}"
   }
 }
 

--- a/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -38,6 +38,10 @@ final case class Configuration(
     transformMemberNames = Configuration.kebabCaseTransformation
   )
 
+  def withPascalCaseMemberNames: Configuration = copy(
+    transformMemberNames = Configuration.pascalCaseTransformation
+  )
+
   def withSnakeCaseConstructorNames: Configuration = copy(
     transformConstructorNames = Configuration.snakeCaseTransformation
   )
@@ -48,6 +52,10 @@ final case class Configuration(
 
   def withKebabCaseConstructorNames: Configuration = copy(
     transformConstructorNames = Configuration.kebabCaseTransformation
+  )
+
+  def withPascalCaseConstructorNames: Configuration = copy(
+    transformConstructorNames = Configuration.pascalCaseTransformation
   )
 
   def withDefaults: Configuration = copy(useDefaults = true)
@@ -75,6 +83,10 @@ object Configuration {
   val kebabCaseTransformation: String => String = s => {
     val partial = basePattern.matcher(s).replaceAll("$1-$2")
     swapPattern.matcher(partial).replaceAll("$1-$2").toLowerCase
+  }
+
+  val pascalCaseTransformation: String => String = s => {
+    s"${Character.toUpperCase(s.charAt(0))}${s.substring(1)}"
   }
 }
 

--- a/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -235,7 +235,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
 
   property("Configuration#transformConstructorNames should support constructor name transformation with PascalCase") {
     forAll { foo: ConfigExampleFoo =>
-      implicit val kebabCaseConfig: Configuration =
+      implicit val pascalCaseConfig: Configuration =
         Configuration.default.withDiscriminator("type").withPascalCaseConstructorNames
 
       import foo._

--- a/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -89,7 +89,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     }
   }
 
-  property("Configuration#transformMemberNames should support member name transformation using PascalCase")  {
+  property("Configuration#transformMemberNames should support member name transformation using PascalCase") {
     forAll { foo: ConfigExampleFoo =>
       implicit val pascalCaseConfig: Configuration = Configuration.default.withPascalCaseMemberNames
 

--- a/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -89,6 +89,18 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     }
   }
 
+  property("Configuration#transformMemberNames should support member name transformation using PascalCase")  {
+    forAll { foo: ConfigExampleFoo =>
+      implicit val pascalCaseConfig: Configuration = Configuration.default.withPascalCaseMemberNames
+
+      import foo._
+      val json = json"""{ "ThisIsAField": $thisIsAField, "a": $a, "b": $b}"""
+
+      assert(Encoder[ConfigExampleFoo].apply(foo) === json)
+      assert(Decoder[ConfigExampleFoo].decodeJson(json) === Right(foo))
+    }
+  }
+
   property("Configuration#useDefaults should support using default values during decoding") {
     forAll { (f: String, b: Double) =>
       implicit val withDefaultsConfig: Configuration = Configuration.default.withDefaults
@@ -215,6 +227,19 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
 
       import foo._
       val json = json"""{ "type": "config-example-foo", "thisIsAField": $thisIsAField, "a": $a, "b": $b}"""
+
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformConstructorNames should support constructor name transformation with PascalCase") {
+    forAll { foo: ConfigExampleFoo =>
+      implicit val kebabCaseConfig: Configuration =
+        Configuration.default.withDiscriminator("type").withPascalCaseConstructorNames
+
+      import foo._
+      val json = json"""{ "type": "ConfigExampleFoo", "thisIsAField": $thisIsAField, "a": $a, "b": $b}"""
 
       assert(Encoder[ConfigExampleBase].apply(foo) === json)
       assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))


### PR DESCRIPTION
Hi, with this pull request support for PascalCasing is added.
I ran into the case an external API was sending me PascalCased JSON and i was unable to parse it.
So I wrote this helper method to do this automatically.

Example:
```
{
 "Hello": "world"
}

case class Hello(hello: String)  // Will be parsed to Hello(world)
```

Somehow one test is failing and I have no idea why. Some help is appreciated there. 
I did a local release and the code does work in my app.