### PR TITLE
Use updated API in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ case class Foo(fooBar: String)
 
 implicit val customConfig: Configuration = Configuration.default.withKebabCaseMemberNames
 
-implicit val fooEncoder: Encoder[Foo] = deriveEncoder
-implicit val fooDecoder: Decoder[Foo] = deriveDecoder
+implicit val fooEncoder: Encoder[Foo] = deriveConfiguredEncoder
+implicit val fooDecoder: Decoder[Foo] = deriveConfiguredDecoder
 ```
 
 ## Contributors and participation


### PR DESCRIPTION
`deriveEncoder` and `deriveDecoder` were deprecated in favor of `deriveConfiguredEncoder` and `deriveConfiguredDecoder`. The readme should reflect this change so users don't immediately encounter deprecation warnings.