### PR TITLE
Sign releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val genericExtrasJS = genericExtras.js
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  releaseVcsSign := true,
   homepage := Some(url("https://github.com/circe/circe-generic-extras")),
   licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   publishMavenStyle := true,


### PR DESCRIPTION
I'll go ahead and publish 0.13.0 for Scala.js 1.0.0 after this lands if there are no objections (from master, since there have been no changes except for build-related things since 0.13.0).