### PR TITLE
Introduce `implicitNotFound` annotation on derived codec classes

### DIFF
--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
@@ -6,10 +6,18 @@ import io.circe.generic.extras.{ Configuration, JsonKey }
 import io.circe.generic.extras.decoding.ConfiguredDecoder
 import io.circe.generic.extras.encoding.ConfiguredAsObjectEncoder
 import io.circe.generic.extras.util.RecordToMap
+import scala.annotation.implicitNotFound
 import shapeless.{ Annotations, Coproduct, Default, HList, LabelledGeneric, Lazy }
 import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class ConfiguredAsObjectCodec[A] extends DerivedAsObjectCodec[A]
 
 object ConfiguredAsObjectCodec {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
@@ -12,7 +12,7 @@ import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ConfiguredAsObjectCodec for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/EnumerationCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/EnumerationCodec.scala
@@ -2,9 +2,17 @@ package io.circe.generic.extras.codec
 
 import io.circe.{ Codec, Decoder, DecodingFailure, HCursor, Json }
 import io.circe.generic.extras.Configuration
+import scala.annotation.implicitNotFound
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.{ FieldType, field }
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class EnumerationCodec[A] extends Codec[A]
 
 object EnumerationCodec {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/EnumerationCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/EnumerationCodec.scala
@@ -7,7 +7,7 @@ import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witnes
 import shapeless.labelled.{ FieldType, field }
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find EnumerationCodec for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
@@ -5,6 +5,7 @@ import io.circe.{ Decoder, DecodingFailure, HCursor, JsonObject }
 import io.circe.generic.extras.ConfigurableDeriver
 import io.circe.generic.extras.decoding.ReprDecoder
 import io.circe.generic.extras.encoding.ReprAsObjectEncoder
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.Map
 import scala.language.experimental.macros
 import shapeless.HNil
@@ -14,6 +15,13 @@ import shapeless.HNil
  *
  * Note that users typically will not work with instances of this class.
  */
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class ReprAsObjectCodec[A] extends ReprDecoder[A] with ReprAsObjectEncoder[A]
 
 object ReprAsObjectCodec {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
@@ -16,7 +16,7 @@ import shapeless.HNil
  * Note that users typically will not work with instances of this class.
  */
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ReprAsObjectCodec for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/UnwrappedCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/UnwrappedCodec.scala
@@ -5,7 +5,7 @@ import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find UnwrappedCodec for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/UnwrappedCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/UnwrappedCodec.scala
@@ -1,8 +1,16 @@
 package io.circe.generic.extras.codec
 
 import io.circe.{ Codec, Decoder, Encoder, HCursor, Json }
+import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class UnwrappedCodec[A] extends Codec[A]
 
 object UnwrappedCodec {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -5,11 +5,19 @@ import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.extras.{ Configuration, JsonKey }
 import io.circe.generic.extras.util.RecordToMap
 import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.Map
 import shapeless.{ Annotations, Coproduct, Default, HList, LabelledGeneric, Lazy }
 import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class ConfiguredDecoder[A](config: Configuration) extends DerivedDecoder[A] {
   private[this] val constructorNameCache: ConcurrentHashMap[String, String] =
     new ConcurrentHashMap[String, String]()

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -12,7 +12,7 @@ import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ConfiguredDecoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
@@ -2,9 +2,17 @@ package io.circe.generic.extras.decoding
 
 import io.circe.{ Decoder, DecodingFailure, HCursor }
 import io.circe.generic.extras.Configuration
+import scala.annotation.implicitNotFound
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.{ FieldType, field }
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class EnumerationDecoder[A] extends Decoder[A]
 
 object EnumerationDecoder {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
@@ -7,7 +7,7 @@ import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witnes
 import shapeless.labelled.{ FieldType, field }
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find EnumerationDecoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -4,6 +4,7 @@ import cats.data.Validated
 import io.circe.{ ACursor, Decoder, DecodingFailure, HCursor }
 import io.circe.Json.JNull
 import io.circe.generic.extras.ConfigurableDeriver
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.Map
 import scala.language.experimental.macros
 import shapeless.HNil
@@ -15,6 +16,13 @@ import shapeless.HNil
  * contains unsafe methods (specifically the two `configuredDecode` methods,
  * which allow passing in an untyped map of default field values).
  */
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class ReprDecoder[A] extends Decoder[A] {
   def configuredDecode(c: HCursor)(
     transformMemberNames: String => String,

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -17,7 +17,7 @@ import shapeless.HNil
  * which allow passing in an untyped map of default field values).
  */
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ReprDecoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/UnwrappedDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/UnwrappedDecoder.scala
@@ -1,8 +1,16 @@
 package io.circe.generic.extras.decoding
 
 import io.circe.{ Decoder, HCursor }
+import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class UnwrappedDecoder[A] extends Decoder[A]
 
 object UnwrappedDecoder {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/decoding/UnwrappedDecoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/decoding/UnwrappedDecoder.scala
@@ -5,7 +5,7 @@ import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find UnwrappedDecoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredAsObjectEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredAsObjectEncoder.scala
@@ -11,7 +11,7 @@ import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ConfiguredAsObjectEncoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredAsObjectEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredAsObjectEncoder.scala
@@ -4,11 +4,19 @@ import io.circe.JsonObject
 import io.circe.generic.encoding.DerivedAsObjectEncoder
 import io.circe.generic.extras.{ Configuration, JsonKey }
 import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.Map
 import shapeless.{ Annotations, Coproduct, HList, LabelledGeneric, Lazy }
 import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class ConfiguredAsObjectEncoder[A](config: Configuration) extends DerivedAsObjectEncoder[A] {
   private[this] val constructorNameCache: ConcurrentHashMap[String, String] =
     new ConcurrentHashMap[String, String]()

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
@@ -7,7 +7,7 @@ import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witnes
 import shapeless.labelled.FieldType
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find EnumerationEncoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
@@ -2,9 +2,17 @@ package io.circe.generic.extras.encoding
 
 import io.circe.{ Encoder, Json }
 import io.circe.generic.extras.Configuration
+import scala.annotation.implicitNotFound
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.FieldType
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class EnumerationEncoder[A] extends Encoder[A]
 
 object EnumerationEncoder {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
@@ -2,6 +2,7 @@ package io.circe.generic.extras.encoding
 
 import io.circe.{ Encoder, Json, JsonObject }
 import io.circe.generic.extras.ConfigurableDeriver
+import scala.annotation.implicitNotFound
 import scala.language.experimental.macros
 
 /**
@@ -9,6 +10,13 @@ import scala.language.experimental.macros
  *
  * Note that users typically will not work with instances of this class.
  */
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 trait ReprAsObjectEncoder[A] extends Encoder.AsObject[A] {
   def configuredEncodeObject(a: A)(
     transformMemberNames: String => String,

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
@@ -1,5 +1,4 @@
 package io.circe.generic.extras.encoding
-
 import io.circe.{ Encoder, Json, JsonObject }
 import io.circe.generic.extras.ConfigurableDeriver
 import scala.annotation.implicitNotFound
@@ -11,7 +10,7 @@ import scala.language.experimental.macros
  * Note that users typically will not work with instances of this class.
  */
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find ReprAsObjectEncoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/UnwrappedEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/UnwrappedEncoder.scala
@@ -1,8 +1,16 @@
 package io.circe.generic.extras.encoding
 
 import io.circe.{ Encoder, Json }
+import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
+@implicitNotFound(
+  """Could not found ConfiguredAsObjectCodec for type ${A}.
+Some possible causes for this:
+- ${A} isn't a case class or sealed trat
+- some of ${A}'s members don't have codecs of their own
+- missing implicit Configuration"""
+)
 abstract class UnwrappedEncoder[A] extends Encoder[A]
 
 object UnwrappedEncoder {

--- a/generic-extras/src/main/scala/io/circe/generic/extras/encoding/UnwrappedEncoder.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/encoding/UnwrappedEncoder.scala
@@ -5,7 +5,7 @@ import scala.annotation.implicitNotFound
 import shapeless.{ ::, Generic, HNil, Lazy }
 
 @implicitNotFound(
-  """Could not found ConfiguredAsObjectCodec for type ${A}.
+  """Could not find UnwrappedEncoder for type ${A}.
 Some possible causes for this:
 - ${A} isn't a case class or sealed trat
 - some of ${A}'s members don't have codecs of their own


### PR DESCRIPTION
Resolves https://github.com/circe/circe-generic-extras/issues/56 

This PR introduces friendly compiler error for missing implicit cases. There's a following problem this PR solves. 

Say you want to have codec for some ADT type, but you forgot to make `sealed` trait:

```scala
trait MyADT extends Product with Serializable
object MyADT {
  case class SomeChild(value: String) extends MyADT
  case object SomeObjectChild extends MyADT

  implicit val codec: Codec[MyADT] = deriveConfiguredCodec[MyADT]
}
```
The compiler fails to compile with following error:
```
could not find Lazy implicit value of type io.circe.generic.extras.codec.ConfiguredAsObjectCodec[MyADT]
     implicit val codec: Codec[MyADT] = deriveConfiguredCodec[MyADT]
```

With this PR the error is
```
Could not found ConfiguredAsObjectCodec for type MyADT.
Some possible causes for this:
- MyADT isn't a case class or sealed trat
- MyADT's members don't have codecs of their own
- missing implicit Configuration
    implicit val codec: Codec[MyADT] = deriveConfiguredCodec[MyADT]
```

Thanks to @kubukoz help solving it in first place 