### PR TITLE
Back to 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 
 scala:
   - 2.12.13
-  - 2.13.5
+  - 2.13.3
 
 jdk:
   - openjdk8


### PR DESCRIPTION
We're seeing very strange issues with the new 0.13.1-M1 release in a project that can't update to Scala 2.13.5 yet because of Scalameta stuff. Publishing circe-generic-extras locally built with 2.13.3 seems fine, so I'm just switching back (it seems like publishing it from 2.13.3 and using it from 2.13.5 is okay, just not the reverse).