### PR TITLE
Add additional possible cause for Configuration implicit error

### DIFF
--- a/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
+++ b/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
@@ -16,7 +16,8 @@ import shapeless.ops.record.Keys
 Some possible causes for this:
 - ${A} isn't a case class or sealed trait
 - some of ${A}'s members don't have codecs of their own
-- missing implicit Configuration"""
+- missing implicit Configuration
+- ambiguous implicit Configurations"""
 )
 abstract class ConfiguredAsObjectCodec[A] extends DerivedAsObjectCodec[A] with ExtrasDecoder[A]
 


### PR DESCRIPTION
Add another possible cause case for this implicit not found error which is if there are multiple Configurations available in scope.

Mentions (since I can't add reviewers...)
@zarthross @zmccoy 